### PR TITLE
Fix auto file type setting

### DIFF
--- a/ftdetect/es6.vim
+++ b/ftdetect/es6.vim
@@ -1,2 +1,2 @@
 " set all `es6` extensions to javascript
-au BufRead,BufNewFile *.{es6,es6.js} filetype=javascript   
+au BufRead,BufNewFile *.{es6,es6.js} set filetype=javascript   


### PR DESCRIPTION
I was getting an error when loading a file with a `.es6` extension. This fixes it.
